### PR TITLE
Fixing configuration property for micropython driver.

### DIFF
--- a/max44009.py
+++ b/max44009.py
@@ -46,7 +46,7 @@ class MAX44009:
 
     @configuration.setter
     def configuration(self, value):
-        self._config = value
+        self._config = bytearray(value)
         self.i2c.writeto_mem(self.address, _MAX44009_REG_CONFIGURATION, self._config)
 
     @property

--- a/max44009_lowmem.py
+++ b/max44009_lowmem.py
@@ -17,7 +17,7 @@ class MAX44009:
 
     @configuration.setter
     def configuration(self, value):
-        self._config = value
+        self._config = bytearray(value)
         self.i2c.writeto_mem(self.address, 0x02, self._config)   # Register configuration
 
     @property


### PR DESCRIPTION
Hi, thanks for making this driver available.
I have the sensor and I use it with an ESP32 which runs MicroPython v1.11-586-g1530fda9c.

I needed to change a couple of lines from the original driver to make it work. Otherwise, I'd get the following exception:

```
TypeError: object with buffer protocol required
```

I think Micropython's API changed since you last updated the driver.

Cheers